### PR TITLE
Allow element types other than Float64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - release
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/\${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("NLsolve")'
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("NLsolve"); Pkg.test("NLsolve"; coverage=true)'

--- a/src/trust_region.jl
+++ b/src/trust_region.jl
@@ -25,7 +25,7 @@ function dogleg!{T}(p::Vector{T}, r::Vector{T}, d::Vector{T}, J::AbstractMatrix{
     try
         p_i = -J\r # Gauss-Newton step
     catch e
-        if isa(e, Base.LinAlg.LAPACKException)
+        if isa(e, Base.LinAlg.LAPACKException) || isa(e, Base.LinAlg.SingularException)
             # If Jacobian is singular, compute a least-squares solution to J*x+r=0
             U, S, V = svd(full(J)) # Convert to full matrix because sparse SVD not implemented as of Julia 0.3
             k = sum(S .> eps())

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -24,10 +24,24 @@ r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = false)
 @assert converged(r)
 @assert norm(r.zero - [ 0; 1]) < 1e-8
 
+r = nlsolve(df, [ -0.5f0; 1.4f0], method = :trust_region, autoscale = true)
+@assert eltype(r.zero) == Float32
+@assert converged(r)
+@assert norm(r.zero - [ 0; 1]) < 1e-8
+r = nlsolve(df, [ -0.5f0; 1.4f0], method = :trust_region, autoscale = false)
+@assert eltype(r.zero) == Float32
+@assert converged(r)
+@assert norm(r.zero - [ 0; 1]) < 1e-8
+
 # Test Newton
 r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.backtracking_linesearch!, ftol = 1e-6)
 @assert converged(r)
 @assert norm(r.zero - [ 0; 1]) < 1e-6
+r = nlsolve(df, [ -0.5f0; 1.4f0], method = :newton, linesearch! = Optim.backtracking_linesearch!, ftol = 1e-3)
+@assert eltype(r.zero) == Float32
+@assert converged(r)
+@assert norm(r.zero - [ 0; 1]) < 1e-6
+
 # Tests of other lineasearches are disabled, they are not stable across runs
 #r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.hz_linesearch!, ftol = 1e-6)
 #@assert converged(r)

--- a/test/singular.jl
+++ b/test/singular.jl
@@ -25,3 +25,18 @@ df = DifferentiableMultivariateFunction(f!, g!)
 r = nlsolve(df, [ 3.0; 0], method = :trust_region)
 @assert converged(r)
 @assert norm(r.zero) < 1e-6
+
+let a = rand(10)
+    const A = a*a'
+    global f!, g!
+    function f!(x, fvec)
+        copy!(fvec, A*x)
+    end
+
+    function g!(x, fjac)
+        copy!(fjac, A)
+    end
+end
+
+df = DifferentiableMultivariateFunction(f!, g!)
+r = nlsolve(df, rand(10), method = :trust_region)


### PR DESCRIPTION
The motivation here is to make it possible to pass starting points that are vectors of `Float32`, and have NLsolve (1) not throw an error, and (2) perform all internal computations with matching precision.

This is built on top of #16, so it's a little harder to review---you can look at just the final commit.
