### PR TITLE
Fix type for singular problems

### DIFF
--- a/src/trust_region.jl
+++ b/src/trust_region.jl
@@ -29,7 +29,7 @@ function dogleg!{T}(p::Vector{T}, r::Vector{T}, d2::Vector{T}, J::AbstractMatrix
             # If Jacobian is singular, compute a least-squares solution to J*x+r=0
             U, S, V = svd(full(J)) # Convert to full matrix because sparse SVD not implemented as of Julia 0.3
             k = sum(S .> eps())
-            mrinv = V * diagm([1./S[1:k]; zeros(length(S)-k)]) * U' # Moore-Penrose generalized inverse of J
+            mrinv = V * diagm([1./S[1:k]; zeros(eltype(S), length(S)-k)]) * U' # Moore-Penrose generalized inverse of J
             p_i = mrinv * r
         else
             throw(e)

--- a/test/singular.jl
+++ b/test/singular.jl
@@ -5,13 +5,13 @@
 
 function f!(x, fvec)
     fvec[1] = x[1]
-    fvec[2] = 10*x[1]/(x[1]+0.1)+2*x[2]^2
+    fvec[2] = 10*x[1]/(x[1]+convert(eltype(x), 0.1))+2*x[2]^2
 end
 
 function g!(x, fjac)
     fjac[1, 1] = 1
     fjac[1, 2] = 0
-    fjac[2, 1] = 1/(x[1]+0.1)^2
+    fjac[2, 1] = 1/(x[1]+convert(eltype(x), 0.1))^2
     fjac[2, 2] = 4*x[2]
 end
 
@@ -23,6 +23,10 @@ df = DifferentiableMultivariateFunction(f!, g!)
 #@assert norm(r.zero) < 1e-5
 
 r = nlsolve(df, [ 3.0; 0], method = :trust_region)
+@assert converged(r)
+@assert norm(r.zero) < 1e-6
+
+r = nlsolve(df, [3.0f0; 0], method = :trust_region)
 @assert converged(r)
 @assert norm(r.zero) < 1e-6
 


### PR DESCRIPTION
Without the change to trust_region.jl, the new test would trigger:
```jl
ERROR: MethodError: `wnorm` has no method matching wnorm(::Array{Float32,1}, ::Array{Float64,1})
```
