### PR TITLE
fix bug in objective function creator in newton.jl

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -28,11 +28,11 @@ function create_objective_function(df::AbstractDifferentiableMultivariateFunctio
     end
     function go!(x::Vector{T}, storage::Vector{T})
         df.fg!(x, fvec2, fjac2)
-        storage = fjac2'*fvec2
+        copy!(storage, fjac2'*fvec2)
     end
     function fgo!(x::Vector{T}, storage::Vector{T})
         df.fg!(x, fvec2, fjac2)
-        storage = fjac2'*fvec2
+        copy!(storage, fjac2'*fvec2)
         return(dot(fvec2, fvec2)/2)
     end
 


### PR DESCRIPTION
The previous version simply bounded the input argument to an array but this doesn't do what is desired which is to update the actual input storage vector.

Without this I have problems where my iterations stalls with something like:


```jl
Iter     f(x) inf-norm    Step 2-norm 
------   --------------   --------------
     0     1.554002e+07              NaN
     1     4.528678e-01     1.586823e+14
     2     4.528678e-01     0.000000e+00
     3     4.528678e-01     0.000000e+00
     4     4.528678e-01     0.000000e+00
     5     4.528678e-01     0.000000e+00
     6     4.528678e-01     0.000000e+00
     7     4.528678e-01     0.000000e+00
     8     4.528678e-01     0.000000e+00
```

with this patch it works.

cc @timholy @sebastien-villemot @spencerlyon2 