### PR TITLE
Modernize test suite

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -28,11 +28,11 @@ function create_objective_function(df::AbstractDifferentiableMultivariateFunctio
     end
     function go!(x::Vector{T}, storage::Vector{T})
         df.fg!(x, fvec2, fjac2)
-        storage = fjac2'*fvec2
+        copy!(storage, fjac2'*fvec2)
     end
     function fgo!(x::Vector{T}, storage::Vector{T})
         df.fg!(x, fvec2, fjac2)
-        storage = fjac2'*fvec2
+        copy!(storage, fjac2'*fvec2)
         return(dot(fvec2, fvec2)/2)
     end
 

--- a/test/2by2.jl
+++ b/test/2by2.jl
@@ -1,6 +1,6 @@
 # Example from Nocedal & Wright, p. 281
 # Used to test all the different algorithms
-
+@testset "2by2" begin
 function f!(x, fvec)
     fvec[1] = (x[1]+3)*(x[2]^3-7)+18
     fvec[2] = sin(x[2]*exp(x[1])-1)
@@ -18,34 +18,35 @@ df = DifferentiableMultivariateFunction(f!, g!)
 
 # Test trust region
 r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = true)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = false)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
 r = nlsolve(df, [ -0.5f0; 1.4f0], method = :trust_region, autoscale = true)
-@assert eltype(r.zero) == Float32
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test eltype(r.zero) == Float32
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 r = nlsolve(df, [ -0.5f0; 1.4f0], method = :trust_region, autoscale = false)
-@assert eltype(r.zero) == Float32
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test eltype(r.zero) == Float32
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
 # Test Newton
 r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.backtracking_linesearch!, ftol = 1e-6)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-6
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-6
 r = nlsolve(df, [ -0.5f0; 1.4f0], method = :newton, linesearch! = Optim.backtracking_linesearch!, ftol = 1e-3)
-@assert eltype(r.zero) == Float32
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-6
+@test eltype(r.zero) == Float32
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-6
 
 # Tests of other lineasearches are disabled, they are not stable across runs
 #r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.hz_linesearch!, ftol = 1e-6)
-#@assert converged(r)
-#@assert norm(r.zero - [ 0; 1]) < 1e-6
+#@test converged(r)
+#@test norm(r.zero - [ 0; 1]) < 1e-6
 #r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.interpolating_linesearch!, ftol = 1e-6)
-#@assert converged(r)
-#@assert norm(r.zero - [ 0; 1]) < 1e-6
+#@test converged(r)
+#@test norm(r.zero - [ 0; 1]) < 1e-6
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/already_converged.jl
+++ b/test/already_converged.jl
@@ -1,5 +1,5 @@
 # Verify that we handle correctly the case where the starting point is a zero
-
+@testset "already converged" begin
 function f!(x, fvec)
     fvec[1] = (x[1]+3)*(x[2]^3-7)+18
     fvec[2] = sin(x[2]*exp(x[1])-1)
@@ -8,11 +8,12 @@ end
 df = DifferentiableMultivariateFunction(f!)
 
 r = nlsolve(df, [ 0.; 1.], method = :trust_region)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
-@assert r.iterations == 0
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
+@test r.iterations == 0
 
 r = nlsolve(df, [ 0.; 1.], method = :newton)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
-@assert r.iterations == 0
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
+@test r.iterations == 0
+end

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -1,10 +1,11 @@
 # Test automatic differentiation
-
+@testset "autodiff" begin
 function f!(x, fvec)
     fvec[1] = (x[1]+3)*(x[2]^3-7)+18
     fvec[2] = sin(x[2]*exp(x[1])-1)
 end
 
 r = nlsolve(f!, [ -0.5; 1.4], autodiff = true)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
+end

--- a/test/difficult_mcp.jl
+++ b/test/difficult_mcp.jl
@@ -2,7 +2,7 @@
 #
 # Presented in Miranda and Fackler (2002): "Applied Computational Economics and
 # Finance", p. 51
-
+@testset "difficult_mcp" begin
 function f!(x, fvec)
     fvec[1] = (1-x[1])^2-1.01
 end
@@ -16,5 +16,6 @@ df = DifferentiableMultivariateFunction(f!, g!)
 solution = [ 2.004987562 ]
 
 r = mcpsolve(df, [0.], [Inf], [0.1], method = :newton)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
+end

--- a/test/finite_difference.jl
+++ b/test/finite_difference.jl
@@ -1,4 +1,5 @@
 # Test the finite differencing technique
+@testset "finite_difference" begin
 
 function f!(x, fvec)
     fvec[1] = (x[1]+3)*(x[2]^3-7)+18
@@ -7,5 +8,6 @@ end
 
 r = nlsolve(f!, [ 0.1; 1.2])
 
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
+end

--- a/test/iface.jl
+++ b/test/iface.jl
@@ -1,5 +1,7 @@
 # Test all the various ways of specifying a function
 
+@testset "iface" begin
+
 # Using functions modifying in-place
 
 function f!(x, fvec)
@@ -26,25 +28,25 @@ function fg!(x, fvec, fjac)
 end
 
 r = nlsolve(DifferentiableMultivariateFunction(f!), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(DifferentiableMultivariateFunction(f!, g!), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(DifferentiableMultivariateFunction(f!, g!, fg!), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(f!, [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(f!, g!, [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(only_f!_and_fg!(f!, fg!), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(only_fg!(fg!), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 
 # Using functions returning their output
@@ -80,13 +82,13 @@ function fg(x)
 end
 
 r = nlsolve(not_in_place(f), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(not_in_place(f, g), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 r = nlsolve(not_in_place(f, g, fg), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
 
 
 # Using functions taking scalar as inputs
@@ -98,4 +100,6 @@ function f(x, y)
 end
 
 r = nlsolve(n_ary(f), [ -0.5; 1.4])
-@assert converged(r)
+@test converged(r)
+
+end

--- a/test/josephy.jl
+++ b/test/josephy.jl
@@ -1,5 +1,7 @@
 # MCP example by Josephy.
 
+@testset "mcp_josephy" begin
+
 function f!(x, fvec)
     fvec[1]=3*x[1]^2+2*x[1]*x[2]+2*x[2]^2+x[3]+3*x[4]-6
     fvec[2]=2*x[1]^2+x[1]+x[2]^2+3*x[3]+2*x[4]-2
@@ -34,43 +36,45 @@ df = DifferentiableMultivariateFunction(f!, g!)
 # Test smooth reformulation with trust region
 
 r = mcpsolve(df, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, g!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :smooth, autodiff = true)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 
 # Test minmax reformulation with trust region
 
 r = mcpsolve(df, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, g!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 r = mcpsolve(f!, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], reformulation = :minmax, autodiff = true)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
 
 
 # Test with Newton method
 
 r = mcpsolve(df, [0.00, 0.00, 0.00, 0.00], [1e20, 1e20, 1e20, 1e20], [1.25, 0.00, 0.00, 0.50], method = :newton)
-@assert converged(r)
-@assert norm(r.zero - solution) < 1e-8
+@test converged(r)
+@test norm(r.zero - solution) < 1e-8
+
+end

--- a/test/minpack.jl
+++ b/test/minpack.jl
@@ -9,7 +9,7 @@
 #   MINPACK would test also other initial points which are 10 or 100 times the
 #   original point.
 
-using Compat
+@testset "minpack" begin
 
 function rosenbrock()
     function f!(x::Vector, fvec::Vector)
@@ -502,12 +502,14 @@ for (df, initial, name) in alltests
     tot_time = toq()
     @printf("%-30s   %5d   %5d   %5d   %14e   %10e\n", name, length(initial),
             r.f_calls, r.g_calls, r.residual_norm, tot_time)
-    @assert converged(r)
+    @test converged(r)
     # with autodiff
     tic()
     r = nlsolve(df.f!, initial, method = :trust_region, autodiff = true)
     tot_time = toq()
     @printf("%-30s   %5d   %5d   %5d   %14e   %10e\n", name*"-AD",
             length(initial), r.f_calls, r.g_calls, r.residual_norm, tot_time)
-    @assert converged(r)
+    @test converged(r)
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,14 @@
 using NLsolve
+using Compat
+
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+
 
 tests = ["2by2.jl",
          "singular.jl",
@@ -14,12 +24,5 @@ tests = ["2by2.jl",
 println("Running tests:")
 
 for test in tests
-    try
-        include(test)
-        println("\t\033[1m\033[32mPASSED\033[0m: $(test)")
-     catch e
-        println("\t\033[1m\033[31mFAILED\033[0m: $(test)")
-        showerror(STDOUT, e, backtrace())
-        rethrow(e)
-     end
+    include(test)    
 end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1,6 +1,8 @@
 # Test sparse Jacobian implementation (even though the Jacobian of the function
 # is actually not sparse...)
 
+@testset "sparse" begin
+
 function f!(x, fvec)
     fvec[1] = (x[1]+3)*(x[2]^3-7)+18
     fvec[2] = sin(x[2]*exp(x[1])-1)
@@ -18,20 +20,22 @@ df = DifferentiableSparseMultivariateFunction(f!, g!)
 
 # Test trust region
 r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = true)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
 # Test Newton
 r = nlsolve(df, [ -0.5; 1.4], method = :newton, linesearch! = Optim.backtracking_linesearch!, ftol = 1e-6)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-6
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-6
 
 # Test MCP solver with smooth reformulation
 r = mcpsolve(df, [-Inf;-Inf], [Inf; Inf], [-0.5; 1.4], reformulation = :smooth)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
 
 # Test MCP solver with minmax reformulation
 r = mcpsolve(df, [-Inf;-Inf], [Inf; Inf], [-0.5; 1.4], reformulation = :minmax)
-@assert converged(r)
-@assert norm(r.zero - [ 0; 1]) < 1e-8
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
+
+end


### PR DESCRIPTION
This modernizes the test suite to use the `@test` macros together with using the https://github.com/IainNZ/BaseTestNext.jl package which is the new test merged into v0.5.

I pushed this on top of #24 since I expect that to get merged and wanted to save a rebase.