### PR TITLE
remove unused call to dfo!

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -86,9 +86,6 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
 
     dfo = create_objective_function(df, T, nn)
 
-    # Keep track of step-sizes
-    foval = dfo.fg!(x, gr)
-
     while !converged && it < iterations
 
         it += 1


### PR DESCRIPTION
AFAIU this call does not do anything.

The return value is not used and the gr-vector is simply passed to the linesearch where it is immediately overwritten, https://github.com/JuliaOpt/Optim.jl/blob/d9f959480b8ced00572f3140dd85822e74fc0d03/src/linesearch/backtracking_linesearch.jl#L26