### PR TITLE
Add DifferentiableGivenSparseMultivariateFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ can be achieved with:
     empty!(gx.rowval)
     empty!(gx.nzval)
 
+
+Another solution is to directly pass a Jacobian matrix with a given sparsity. To do so, construct an object of type `DifferentiableGivenSparseMultivariateFunction`
+
+    df = DifferentiableGivenSparseMultivariateFunction(f!, g!, J)
+    nlsolve(df, initial_x)
+
+If  `g!` conserves the sparsity structure of `gx`, `gx` will always have the same sparsity as `J`. This sometimes allow to write a faster version of `g!`.
+
 # Fine tunings
 
 Two algorithms are currently available. The choice between the two is achieved

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -19,6 +19,7 @@ export DifferentiableMultivariateFunction,
        not_in_place,
        n_ary,
        DifferentiableSparseMultivariateFunction,
+       DifferentiableGivenSparseMultivariateFunction,
        nlsolve,
        mcpsolve,
        converged

--- a/src/differentiable_functions.jl
+++ b/src/differentiable_functions.jl
@@ -113,3 +113,22 @@ function DifferentiableSparseMultivariateFunction(f!::Function, g!::Function)
     end
     return DifferentiableSparseMultivariateFunction(f!, g!, fg!)
 end
+
+
+immutable DifferentiableGivenSparseMultivariateFunction{Tv, Ti} <: AbstractDifferentiableMultivariateFunction
+    f!::Function
+    g!::Function
+    fg!::Function
+    J::SparseMatrixCSC{Tv, Ti}
+end
+
+alloc_jacobian(df::DifferentiableGivenSparseMultivariateFunction, args...) = deepcopy(df.J)
+
+function DifferentiableGivenSparseMultivariateFunction(f!::Function, g!::Function, J::SparseMatrixCSC)
+    function fg!(x::Vector, fx::Vector, gx::SparseMatrixCSC)
+        f!(x, fx)
+        g!(x, gx)
+    end
+    DifferentiableGivenSparseMultivariateFunction(f!, g!, fg!, J)
+end
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 sumabs2j(S::AbstractMatrix, j::Integer) = sumabs2(slice(S, :, j))
 
-function sumabs2j(S::Base.SparseMatrix.SparseMatrixCSC, j::Integer)
+function sumabs2j(S::SparseMatrixCSC, j::Integer)
     sumabs2(sub(nonzeros(S), nzrange(S, j)))
 end
 

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -38,4 +38,10 @@ r = mcpsolve(df, [-Inf;-Inf], [Inf; Inf], [-0.5; 1.4], reformulation = :minmax)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
 
+# Test given sparse
+df = DifferentiableGivenSparseMultivariateFunction(f!, g!, spzeros(2, 2))
+r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = true)
+@test converged(r)
+@test norm(r.zero - [ 0; 1]) < 1e-8
+
 end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -39,7 +39,7 @@ r = mcpsolve(df, [-Inf;-Inf], [Inf; Inf], [-0.5; 1.4], reformulation = :minmax)
 @test norm(r.zero - [ 0; 1]) < 1e-8
 
 # Test given sparse
-df = DifferentiableGivenSparseMultivariateFunction(f!, g!, spzeros(2, 2))
+df = DifferentiableGivenSparseMultivariateFunction(f_sparse!, g_sparse!, spzeros(2, 2))
 r = nlsolve(df, [ -0.5; 1.4], method = :trust_region, autoscale = true)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8


### PR DESCRIPTION
When solving a problem with sparse Jacobian, it's sometimes faster to write the `g!` function assuming that the given jacobian matrix has a certain sparsity structure. 