### PR TITLE
use identically equal in comparing input vector to linesearch gradient

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -78,7 +78,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
     # in case of the line search asking us for the gradient at xₖ.
     function go!(xlin::Vector, storage::Vector)
         df.f!(xlin, fvec2)
-        if xlin == xold
+        if xlin === xold
             copy!(storage, fjac'*fvec2)
         # Else we need to recompute it.
         else


### PR DESCRIPTION
The linesearches in Optim does not copy the input vectors so there is no point in comparing element by element. Instead we can just compare using ===.