### PR TITLE
improve autodiff option

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 Optim
 Calculus
-ForwardDiff
+ForwardDiff 0.1.4 0.2
 Distances

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -2,12 +2,39 @@
 # assuming that f takes a Vector{T} of length n
 # and writes the result to a Vector{T} of length m
 
-# TODO: Update chunk_size to ~10 when https://github.com/JuliaDiff/ForwardDiff.jl/issues/36
+# TODO: Update chunk_size to constant ~10 when https://github.com/JuliaDiff/ForwardDiff.jl/issues/36
 # is resolved
-function autodiff{T <: Real}(f!,::Type{T}, m)
-    permf!(yp, xp) = f!(xp, yp)
-    permg! = jacobian(permf!, mutates = true, output_length = m, chunk_size = 1)
-    g!(x, fx) = permg!(fx, x)
 
-    return DifferentiableMultivariateFunction(f!, g!)
+# Compute the chunk size so that the chunk size is smaller than
+# ForwardDiff.tuple_usage_threshold and evenly divides the input length
+function compute_chunk_size(length_x0)
+    chunk_size = ForwardDiff.tuple_usage_threshold
+    while chunk_size > 1
+        if isinteger(length_x0 / chunk_size)
+            break
+        else
+            chunk_size -= 1
+        end
+    end
+    return chunk_size
+end
+
+function autodiff{T <: Real}(f!, ::Type{T}, length_x0)
+
+    cache = ForwardDiffCache()
+    nl_chunk_size = compute_chunk_size(length_x0)
+
+    permf!(yp, xp) = f!(xp, yp)
+    permg! = jacobian(permf!, mutates = true, output_length = length_x0,
+                      chunk_size = nl_chunk_size, cache = cache)
+    permg_allres! = jacobian(permf!, ForwardDiff.AllResults, mutates = true,
+                             output_length = length_x0, chunk_size = nl_chunk_size, cache = cache)
+
+    g!(x, gx) = permg!(gx, x)
+
+    function fg!(x, fx, gx)
+        _, all_results = permg_allres!(gx, x)
+        ForwardDiff.value!(fx, all_results)
+    end
+    return DifferentiableMultivariateFunction(f!, g!, fg!)
 end

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -8,4 +8,12 @@ end
 r = nlsolve(f!, [ -0.5; 1.4], autodiff = true)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
+
+@test NLsolve.compute_chunk_size(12) == 6
+@test NLsolve.compute_chunk_size(13) == 1
+@test NLsolve.compute_chunk_size(9) == 9
+@test NLsolve.compute_chunk_size(25) == 5
+@test NLsolve.compute_chunk_size(20) == 10
+@test NLsolve.compute_chunk_size(1) == 1
+
 end


### PR DESCRIPTION
- Also generate a fg! function using the `ForwardDiff.AllResult` option, see http://www.juliadiff.org/ForwardDiff.jl/lower_order_results.html
- Try to find a chunk_size that divides the input length but is smaller or equal to `ForwardDiff.tuple_usage_threshold`

Does this look reasonable @jrevels @mlubin? Thanks