### PR TITLE
add test for counting number of function and gradient calls 

### DIFF
--- a/test/f_g_counts.jl
+++ b/test/f_g_counts.jl
@@ -1,0 +1,40 @@
+# This file tests if the number of f and g calls are correctly counted
+@testset "f_g_counts" begin
+
+    fcalls = Ref(0)
+    gcalls = Ref(0)
+
+    function f_counts_ref!(x::Vector, fvec::Vector, fcalls)
+        fcalls[] += 1
+        fvec[1] = 1 - x[1]
+        fvec[2] = 10(x[2]-x[1]^2)
+    end
+    f_counts!(x, fvec) = f_counts_ref!(x, fvec, fcalls)
+
+    function g_counts_ref!(x::Vector, fjac::Matrix, gcalls)
+        gcalls[] += 1
+        fjac[1,1] = -1
+        fjac[1,2] = 0
+        fjac[2,1] = -20x[1]
+        fjac[2,2] = 10
+    end
+    g_counts!(x, fjac) = g_counts_ref!(x, fjac, gcalls)
+
+    df = DifferentiableMultivariateFunction(f_counts!, g_counts!)
+
+    x0 = [-1.2; 1.]
+
+    fcalls[] = 0
+    gcalls[] = 0
+
+    r = nlsolve(df, x0, method = :trust_region)
+    @test r.f_calls == fcalls[]
+    @test r.g_calls == gcalls[]
+
+    fcalls[] = 0
+    gcalls[] = 0
+
+    r = nlsolve(df, x0, method = :newton)
+    @test r.f_calls == fcalls[]
+    @test r.g_calls == gcalls[]
+end

--- a/test/minpack.jl
+++ b/test/minpack.jl
@@ -495,21 +495,23 @@ alltests = [ rosenbrock(); powell_singular(); powell_badly_scaled(); wood();
 @printf("%-30s   %5s   %5s   %5s   %14s     %10s\n", "Function", "Dim", "NFEV",
         "NJEV", "Final inf-norm", "total time")
 println("-"^86)
-
+f_out = open("minpack_results.dat", "w")
 for (df, initial, name) in alltests
-    tic()
-    r = nlsolve(df, initial, method = :trust_region)
-    tot_time = toq()
+
+    tot_time = @elapsed r = nlsolve(df, initial, method = :trust_region)
     @printf("%-30s   %5d   %5d   %5d   %14e   %10e\n", name, length(initial),
             r.f_calls, r.g_calls, r.residual_norm, tot_time)
     @test converged(r)
+    @printf(f_out, "%-30s   %5d   %5d   %5d   %14e\n", name, length(initial),
+            r.f_calls, r.g_calls, r.residual_norm)
     # with autodiff
-    tic()
-    r = nlsolve(df.f!, initial, method = :trust_region, autodiff = true)
-    tot_time = toq()
+    tot_time = @elapsed r_AD = nlsolve(df.f!, initial, method = :trust_region, autodiff = true)
     @printf("%-30s   %5d   %5d   %5d   %14e   %10e\n", name*"-AD",
-            length(initial), r.f_calls, r.g_calls, r.residual_norm, tot_time)
-    @test converged(r)
+            length(initial), r_AD.f_calls, r_AD.g_calls, r_AD.residual_norm, tot_time)
+    @printf(f_out, "%-30s   %5d   %5d   %5d   %14e\n", name*"-AD", length(initial),
+            r_AD.f_calls, r_AD.g_calls, r_AD.residual_norm)
+    @test converged(r_AD)
 end
+close(f_out)
 
 end

--- a/test/minpack_results.dat
+++ b/test/minpack_results.dat
@@ -1,0 +1,42 @@
+Rosenbrock                           2      30      17     0.000000e+00
+Rosenbrock-AD                        2      30      17     0.000000e+00
+Powell singular                      4      17      17     2.945101e-09
+Powell singular-AD                   4      17      17     2.945101e-09
+Powell badly scaled                  2      15      14     7.051804e-12
+Powell badly scaled-AD               2      15      14     7.051804e-12
+Wood                                 4      19      15     1.152565e-10
+Wood-AD                              4      19      15     1.152340e-10
+Helical Valley                       3      10       9     1.110223e-14
+Helical Valley-AD                    3      10       9     1.110223e-14
+Watson                               6      20      16     2.982250e-13
+Watson-AD                            6      20      16     2.903164e-13
+Watson                               9      17      17     1.615243e-12
+Watson-AD                            9      17      17     1.651451e-12
+Chebyquad                            5       8       5     9.143861e-09
+Chebyquad-AD                         5       8       5     9.143861e-09
+Chebyquad                            6      13       8     7.320533e-16
+Chebyquad-AD                         6      13       8     7.320533e-16
+Chebyquad                            7      10       6     6.329061e-10
+Chebyquad-AD                         7      10       6     6.329061e-10
+Chebyquad                            9      14       8     1.631681e-14
+Chebyquad-AD                         9      14       8     1.631681e-14
+Brown almost-linear                 10       5       5     3.382331e-09
+Brown almost-linear-AD              10       5       5     3.382331e-09
+Brown almost-linear                 30       4       4     8.883265e-09
+Brown almost-linear-AD              30       4       4     8.883265e-09
+Brown almost-linear                 40       4       4     1.570839e-09
+Brown almost-linear-AD              40       4       4     1.570839e-09
+Discrete boundary value             10       4       4     2.636780e-16
+Discrete boundary value-AD          10       4       4     2.636780e-16
+Discrete integral equation           1       4       4     8.540391e-14
+Discrete integral equation-AD        1       4       4     8.540391e-14
+Discrete integral equation          10       4       4     2.720046e-15
+Discrete integral equation-AD       10       4       4     2.720046e-15
+Trigonometric                       10      14       8     1.204281e-10
+Trigonometric-AD                    10      14       8     1.204299e-10
+Variably dimensioned                10      15      15     1.323497e-12
+Variably dimensioned-AD             10      15      15     1.323497e-12
+Broyden tridiagonal                 10       5       5     7.548402e-10
+Broyden tridiagonal-AD              10       5       5     7.548402e-10
+Broyden banded                      10       6       6     9.359466e-09
+Broyden banded-AD                   10       6       6     9.359466e-09

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,10 +17,11 @@ tests = ["2by2.jl",
          "josephy.jl",
          "difficult_mcp.jl",
          "sparse.jl",
-         "throws.jl"]
+         "throws.jl",
+         "f_g_counts.jl"]
 
 println("Running tests:")
 
 for test in tests
-    include(test)    
+    include(test)
 end


### PR DESCRIPTION
This adds a test file to make sure that we are counting the number of function and gradient calls correctly.

This is currently true but I am experimenting with some changes and don't want to break anything.

It also creates a file with the number of function calls + gradient calls + residual to check for regressions. It does not track computational time since that is out of scope and would vary between systems.