### PR TITLE
add option to use no linesearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,10 @@ This method is selected with `method = :newton`.
 This method accepts a custom parameter `linesearch!`, which must be equal to a
 function computing the linesearch. Currently, available values are taken from
 the `Optim` package, and are: `Optim.backtracking_linesearch!` (the default),
-`Optim.hz_linesearch!`, `Optim.interpolating_linesearch!`. **Note:** it is assumed
-that the linesearch function will evaluate the function at least once at the
-current point.
+`Optim.hz_linesearch!`, `Optim.interpolating_linesearch!`. To run without
+linesearch, pass the `NLsolve.no_linesearch!` function as argument. **Note:**
+it is assumed that a passed linesearch function will at least update the solution
+vector and evaluate the function at the new point.
 
 ## Common options
 

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -1,3 +1,11 @@
+function no_linesearch!(dfo, xold, p, x, gr, lsr, alpha, mayterminate)
+    @simd for i in eachindex(x)
+        @inbounds x[i] = xold[i] + p[i]
+    end
+    dfo.f(x)
+    return 0.0, 0, 0
+end
+
 macro newtontrace(stepnorm)
     quote
         if tracing

--- a/test/no_linesearch.jl
+++ b/test/no_linesearch.jl
@@ -1,0 +1,11 @@
+@testset "no linesearch" begin
+
+function f_nolin!(x, fvec)
+    fvec[1] = (x[1]+3)*(x[2]^3-7)+18
+    fvec[2] = sin(x[2]*exp(x[1])-1)
+end
+
+r = nlsolve(f_nolin!, [ -0.5; 1.4], autodiff = true, method = :newton, linesearch! = NLsolve.no_linesearch!)
+@test converged(r)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,8 @@ tests = ["2by2.jl",
          "difficult_mcp.jl",
          "sparse.jl",
          "throws.jl",
-         "f_g_counts.jl"]
+         "f_g_counts.jl",
+         "no_linesearch.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
Adds a new "linesearch!" function that simply updates the vector and evaluates the function. 

Also add this to documentation and clearify what is expected of a `linesearch!` function