### PR TITLE
type assert variables modified in closure

### DIFF
--- a/src/newton.jl
+++ b/src/newton.jl
@@ -47,7 +47,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
     gr = Array(T, nn)
 
     # Count function calls
-    f_calls, g_calls = 0, 0
+    f_calls::Int, g_calls::Int = 0, 0
 
     df.fg!(x, fvec, fjac)
     f_calls += 1


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/16441, #49 

Before:

```jl
julia> @time for i in 1:10^4 nlsolve(df!, x0, method = :newton) end
  0.057836 seconds (440.00 k allocations: 22.278 MB, 14.73% gc time)
```

After:

```jl
julia> @time for i in 1:10^4 nlsolve(df!, x0, method = :newton) end
  0.034421 seconds (410.00 k allocations: 21.820 MB, 25.56% gc time)
```