### PR TITLE
upgrade to new ForwardDiff

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 Optim
 Calculus
-ForwardDiff 0.1.4 0.2
 Distances
-Compat 0.7.16
+ForwardDiff 0.2.0
+Compat 0.8.0

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -8,7 +8,6 @@ using ForwardDiff
 using Compat
 
 import Compat.String
-import Optim.newton
 
 import Base.show,
        Base.push!,

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -5,7 +5,9 @@ module NLsolve
 using Distances
 using Optim
 using ForwardDiff
-using Compat: String
+using Compat
+
+import Compat.String
 
 import Base.show,
        Base.push!,

--- a/src/NLsolve.jl
+++ b/src/NLsolve.jl
@@ -8,6 +8,7 @@ using ForwardDiff
 using Compat
 
 import Compat.String
+import Optim.newton
 
 import Base.show,
        Base.push!,

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -1,40 +1,17 @@
-# generates a function that computes the jacobian of f!(x,fx)
-# assuming that f takes a Vector{T} of length n
-# and writes the result to a Vector{T} of length m
+function autodiff(f!, initial_x::Vector)
 
-# TODO: Update chunk_size to constant ~10 when https://github.com/JuliaDiff/ForwardDiff.jl/issues/36
-# is resolved
+    permf! = (fx, x) -> f!(x, fx)
 
-# Compute the chunk size so that the chunk size is smaller than
-# ForwardDiff.tuple_usage_threshold and evenly divides the input length
-function compute_chunk_size(length_x0)
-    chunk_size = ForwardDiff.tuple_usage_threshold
-    while chunk_size > 1
-        if isinteger(length_x0 / chunk_size)
-            break
-        else
-            chunk_size -= 1
-        end
+    fx2 = copy(initial_x)
+    g! = (x, gx) -> begin
+        out = ForwardDiff.JacobianResult(fx2, gx)
+        ForwardDiff.jacobian!(out, permf!, x)
     end
-    return chunk_size
-end
 
-function autodiff{T <: Real}(f!, ::Type{T}, length_x0)
-
-    cache = ForwardDiffCache()
-    nl_chunk_size = compute_chunk_size(length_x0)
-
-    permf!(yp, xp) = f!(xp, yp)
-    permg! = jacobian(permf!, mutates = true, output_length = length_x0,
-                      chunk_size = nl_chunk_size, cache = cache)
-    permg_allres! = jacobian(permf!, ForwardDiff.AllResults, mutates = true,
-                             output_length = length_x0, chunk_size = nl_chunk_size, cache = cache)
-
-    g!(x, gx) = permg!(gx, x)
-
-    function fg!(x, fx, gx)
-        _, all_results = permg_allres!(gx, x)
-        ForwardDiff.value!(fx, all_results)
+    fg! = (x, fx, gx) -> begin
+        out = ForwardDiff.JacobianResult(fx, gx)
+        ForwardDiff.jacobian!(out, permf!, x)
     end
+
     return DifferentiableMultivariateFunction(f!, g!, fg!)
 end

--- a/src/mcp_func_defs.jl
+++ b/src/mcp_func_defs.jl
@@ -78,7 +78,7 @@ function mcpsolve{T}(f!::Function,
     if !autodiff
         df = DifferentiableMultivariateFunction(f!)
     else
-        df = NLsolve.autodiff(f!, eltype(initial_x), length(initial_x))
+        df = NLsolve.autodiff(f!, initial_x)
     end
     @reformulate df
     nlsolve(rf,

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -148,7 +148,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
                          f_calls, g_calls)
 end
 
-function Optim.newton{T}(df::AbstractDifferentiableMultivariateFunction,
+function newton{T}(df::AbstractDifferentiableMultivariateFunction,
                    initial_x::Vector{T},
                    xtol::Real,
                    ftol::Real,

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -148,7 +148,7 @@ function newton_{T}(df::AbstractDifferentiableMultivariateFunction,
                          f_calls, g_calls)
 end
 
-function newton{T}(df::AbstractDifferentiableMultivariateFunction,
+function Optim.newton{T}(df::AbstractDifferentiableMultivariateFunction,
                    initial_x::Vector{T},
                    xtol::Real,
                    ftol::Real,

--- a/src/nlsolve_func_defs.jl
+++ b/src/nlsolve_func_defs.jl
@@ -65,7 +65,7 @@ function nlsolve{T}(f!::Function,
     if !autodiff
         df = DifferentiableMultivariateFunction(f!)
     else
-        df = NLsolve.autodiff(f!, eltype(initial_x), length(initial_x))
+        df = NLsolve.autodiff(f!, initial_x)
     end
     nlsolve(df,
             initial_x, method = method, xtol = xtol, ftol = ftol,

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -9,11 +9,4 @@ r = nlsolve(f!, [ -0.5; 1.4], autodiff = true)
 @test converged(r)
 @test norm(r.zero - [ 0; 1]) < 1e-8
 
-@test NLsolve.compute_chunk_size(12) == 6
-@test NLsolve.compute_chunk_size(13) == 1
-@test NLsolve.compute_chunk_size(9) == 9
-@test NLsolve.compute_chunk_size(25) == 5
-@test NLsolve.compute_chunk_size(20) == 10
-@test NLsolve.compute_chunk_size(1) == 1
-
 end


### PR DESCRIPTION
Also extend the newton definition in Optim so we dont clash with exported functions.

Does the AD stuff look ok to you @jrevels? I wasn't able to get rid of the `fx2 = copy(initial_x)` copy because the function that computes the gradient in place does not have access to the output buffer for the function and this is now needed in ForwardDiff if you want to use the old `mutates=true`.